### PR TITLE
fix friend drawer open property name

### DIFF
--- a/frontend/src/components/BillList.js
+++ b/frontend/src/components/BillList.js
@@ -147,7 +147,7 @@ const BillList = () => {
         </AppBar>
         <Drawer
           anchor='top'
-          isOpen={addingFriend}
+          open={addingFriend}
           onClose={() => { setAddingFriend(false); setNewFriend('') }}
         >
           <Stack spacing={1} direction="row">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "bill-splitting-app",
+  "name": "Bill-Splitting-App",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Fixes the open property that was renamed by find and replace, fixing the visibility of the add friends drawer