### PR TITLE
Fix cors policy to allow all endpoints from default client

### DIFF
--- a/backend/src/main/java/com/cwru/bill_splitting_app/BillSplittingAppApplication.java
+++ b/backend/src/main/java/com/cwru/bill_splitting_app/BillSplittingAppApplication.java
@@ -2,6 +2,9 @@ package com.cwru.bill_splitting_app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 public class BillSplittingAppApplication {
@@ -9,4 +12,14 @@ public class BillSplittingAppApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(BillSplittingAppApplication.class, args);
 	}
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**").allowedOrigins("http://localhost:3000");
+      }
+    };
+  }
 }


### PR DESCRIPTION
Fixes the cross origin policy to allow default client+port to use any endpoint to access data from backend. Addresses #23 